### PR TITLE
[master][CDRP-58] COBAR data processing issue

### DIFF
--- a/include/neutx/container/detail/flat_data_store.hpp
+++ b/include/neutx/container/detail/flat_data_store.hpp
@@ -49,6 +49,9 @@ public:
 
     // convert abstract pointer to native pointer
     template<typename T> T *native_pointer(pointer_t a_ptr) const {
+	if (!a_ptr)
+		return (T*)((char *)0);
+
         if (a_ptr > m_size - sizeof(T))
             throw std::invalid_argument("flat_data_store: bad offset");
         return (T*)((char *)m_start + a_ptr);


### PR DESCRIPTION
As from the name of the function, native_pointer returns an actual address in memory by given offset through adding it to the mapped file starting position. I see from the code, it is covered by checks for null of the function return, but ignores a possibility of the null offset. This approach seems to be kind of useless, since the original function always returns not null result because of the not null mapped file address.
The PR does an additional check before summing values and gives a try for external check to prevent crash in case of a empty function parameter.